### PR TITLE
Fix #72

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,7 +250,7 @@
   </ul>
   <p>
     The [=user agent=] additionally has a <dfn>max queued records</dfn> integer, which
-    is set to an [=implementation-defined=] value, larger than 0.
+    is set to an [=implementation-defined=] value, greater than 0.
     </li>
   </p>
 </section>

--- a/index.html
+++ b/index.html
@@ -248,6 +248,11 @@
       objects, which is initially empty.
     </li>
   </ul>
+  <p>
+    The [=user agent=] additionally has a <dfn>max queued records</dfn> integer, which
+    is set to an [=implementation-defined=] value, larger than 0.
+    </li>
+  </p>
 </section>
 
 <section> <h2>Pressure States</h2>
@@ -544,7 +549,7 @@ The Compute Pressure Observer API enables developers to understand the utilizati
     <p>
       The {{ComputePressureRecord/source}} attribute represents the current [=source type=].
     </p>
-  </section>  
+  </section>
   <section>
     <h3>The <dfn>state</dfn> attribute</h3>
     <p>
@@ -660,7 +665,10 @@ The Compute Pressure Observer API enables developers to understand the utilizati
         Let |record:ComputePressureRecord| be the result of running [=create a record=] with |source| and |state|.
       </li>
       <li>
-        [=Append=] it to |observer|.{{ComputePressureObserver/[[QueuedRecords]]}}.
+        If [=list/size=] of |observer|.{{ComputePressureObserver/[[QueuedRecords]]}} is greater than
+        [=max queued records=], then [=list/remove=] the first [=list/item=].
+      <li>
+        [=list/Append=] |record| to |observer|.{{ComputePressureObserver/[[QueuedRecords]]}}.
       </li>
       <li>
         [=Queue a compute pressure observer task=].


### PR DESCRIPTION
Let the user agent set a max size of the queue


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/compute-pressure/pull/77.html" title="Last updated on Mar 4, 2022, 12:39 PM UTC (07fa44e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/compute-pressure/77/8a6d8b3...kenchris:07fa44e.html" title="Last updated on Mar 4, 2022, 12:39 PM UTC (07fa44e)">Diff</a>