### PR TITLE
Fixes #124, use default value and ensure value is > 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
       a <dfn>[[\Callback]]</dfn> of type {{PressureUpdateCallback}} set on creation.
     </li>
     <li>
-      a <dfn>[[\SampleRate]]</dfn> number set on creation.
+      a <dfn>[[\SampleRate]]</dfn> double set on creation.
     </li>
     <li>
       a <dfn>[[\QueuedRecords]]</dfn> [=queue=] of zero or more {{PressureRecord}}
@@ -478,11 +478,10 @@ of system resources such as the CPU.
           Set |this|.{{PressureObserver/[[Callback]]}} to |callback:PressureUpdateCallback|.
         </li>
         <li>
-          If |options:PressureObserverOptions| is a [=dictionary=] and |options|["sampleRate"] [=map/exists=],
-          set |this:PressureObserver|.{{PressureObserver/[[SampleRate]]}} to it.
+          If |options|["sampleRate"] is less than or equal to 0, throw a {{RangeError}}.
         </li>
         <li>
-          Otherwise, set |this:PressureObserver|.{{PressureObserver/[[SampleRate]]}} to 1.
+          Set |this:PressureObserver|.{{PressureObserver/[[SampleRate]]}} to |options|["sampleRate"].
         </li>
       </ol>
     </p>
@@ -705,7 +704,7 @@ of system resources such as the CPU.
   <h3>The <dfn>PressureObserverOptions</dfn> dictionary</h3>
   <pre class="idl">
     dictionary PressureObserverOptions {
-      double sampleRate;
+      double sampleRate = 1.0;
     };
   </pre>
   <section>


### PR DESCRIPTION
Explanation in https://github.com/w3c/sensors/pull/439


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Timeout :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 21, 2022, 11:50 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fkenchris%2Fcompute-pressure%2F0aa04d362d460271a8be161dac0252359a41463a%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/compute-pressure%23130.)._
</details>
