### PR TITLE
Fixing passes rate test

### DIFF
--- a/index.html
+++ b/index.html
@@ -880,10 +880,13 @@ of system resources such as the CPU.
           Let |sampleRate| be |observer|.{{PressureObserver/[[SampleRate]]}}.
         </li>
         <li>
-          Let |timeDelta:DOMHighResTimeStamp| = |record|.{{PressureRecord/[[Time]]}} - |timestamp|.
+          Let |timeDeltaMilliseconds:DOMHighResTimeStamp| = |timestamp| - |record|.{{PressureRecord/[[Time]]}}.
         </li>
         <li>
-          If |timeDelta| &gt; (1 / |sampleRate|), return true, otherwise return false.
+          Let |interval| = 1 / |sampleRate|.
+        </li>
+        <li>
+          If (|timeDeltaMilliseconds| / 1000) &gt; |interval|, return true, otherwise return false.
         </li>
       </ol>
       The <dfn>has change in data</dfn> steps given the argument |observer:PressureObserver|, |source:PressureSource|,

--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@ of system resources such as the CPU.
           Let |sampleRate| be |observer|.{{PressureObserver/[[SampleRate]]}}.
         </li>
         <li>
-          Let |timeDeltaMilliseconds:DOMHighResTimeStamp| = |timestamp| - |record|.{{PressureRecord/[[Time]]}}.
+          Let |timeDeltaMilliseconds:DOMHighResTimeStamp| = |record|.{{PressureRecord/[[Time]]}} - |timestamp|.
         </li>
         <li>
           Let |interval| = 1 / |sampleRate|.

--- a/index.html
+++ b/index.html
@@ -883,10 +883,10 @@ of system resources such as the CPU.
           Let |timeDeltaMilliseconds:DOMHighResTimeStamp| = |record|.{{PressureRecord/[[Time]]}} - |timestamp|.
         </li>
         <li>
-          Let |interval| = 1 / |sampleRate|.
+          Let |intervalSeconds| = 1 / |sampleRate|.
         </li>
         <li>
-          If (|timeDeltaMilliseconds| / 1000) &gt; |interval|, return true, otherwise return false.
+          If (|timeDeltaMilliseconds| / 1000) &gt; |intervalSeconds|, return true, otherwise return false.
         </li>
       </ol>
       The <dfn>has change in data</dfn> steps given the argument |observer:PressureObserver|, |source:PressureSource|,


### PR DESCRIPTION
Fixing the conversion error between timeDelta and sampleRate inverse.

fixes #138


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/compute-pressure/pull/139.html" title="Last updated on Oct 6, 2022, 1:21 PM UTC (9b68613)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/compute-pressure/139/22a293f...9b68613.html" title="Last updated on Oct 6, 2022, 1:21 PM UTC (9b68613)">Diff</a>