### PR TITLE
Fixes the order of the time subtraction in Passes rate test

### DIFF
--- a/index.html
+++ b/index.html
@@ -880,7 +880,7 @@ of system resources such as the CPU.
           Let |sampleRate| be |observer|.{{PressureObserver/[[SampleRate]]}}.
         </li>
         <li>
-          Let |timeDeltaMilliseconds:DOMHighResTimeStamp| = |record|.{{PressureRecord/[[Time]]}} - |timestamp|.
+          Let |timeDeltaMilliseconds:DOMHighResTimeStamp| = |timestamp| - |record|.{{PressureRecord/[[Time]]}}.
         </li>
         <li>
           Let |intervalSeconds| = 1 / |sampleRate|.


### PR DESCRIPTION
The order of the subtraction is wrong.
The previous time should be subtracted from the current time to be provide a correct time delta.

fixes #140