### PR TITLE
Fixing comparison in passes rate test

### DIFF
--- a/index.html
+++ b/index.html
@@ -886,7 +886,7 @@ of system resources such as the CPU.
           Let |intervalSeconds| = 1 / |sampleRate|.
         </li>
         <li>
-          If (|timeDeltaMilliseconds| / 1000) &gt; |intervalSeconds|, return true, otherwise return false.
+          If (|timeDeltaMilliseconds| / 1000) &ge; |intervalSeconds|, return true, otherwise return false.
         </li>
       </ol>
       The <dfn>has change in data</dfn> steps given the argument |observer:PressureObserver|, |source:PressureSource|,


### PR DESCRIPTION
The comparison between 2 last changes timestamp diff and the sampling interval should be "greater or equal to" instead of "greater than"

fixes #142


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/compute-pressure/pull/143.html" title="Last updated on Oct 10, 2022, 5:52 PM UTC (9f648c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/compute-pressure/143/cbc90b2...9f648c2.html" title="Last updated on Oct 10, 2022, 5:52 PM UTC (9f648c2)">Diff</a>