### PR TITLE
Address FPWD publication blockers

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,7 +506,11 @@ of system resources such as the CPU.
         <li>
           Run the following steps [=in parallel=]:
           <ol>
-            <aside class="issue" data-number="110"></aside>
+            <aside class="issue">
+              <a href="https://github.com/wicg/compute-pressure/issues/110">
+                Permission policy doesn't support workers yet #110
+              </a>
+            </aside>
             <li>
               Let |permissionState:PermissionState| be the result of
               [=getting the current permission state=] with <a>"compute-pressure"</a>.
@@ -671,7 +675,7 @@ of system resources such as the CPU.
               [=requesting permission to use=] the [=powerful feature=] [=powerful feature/named=] <a>"compute-pressure"</a>.
             </li>
             <li>
-              [=Queue a global task=] on the [=permissions task source=] with [=this=]'s
+              [=Queue a global task=] on the [=user interaction task source=] with [=this=]'s
               [=relevant global object=] to [=resolve=] |result| with |permissionState|.
             </li>
           </ol>


### PR DESCRIPTION
- Use user interaction task source instead of still evolving permissions task source. https://github.com/w3c/permissions/pull/407

- Replace auto-generated issue 110 with a normal inline issue


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anssiko/compute-pressure/pull/155.html" title="Last updated on Dec 13, 2022, 8:51 AM UTC (7dbef78)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/compute-pressure/155/5ab1435...anssiko:7dbef78.html" title="Last updated on Dec 13, 2022, 8:51 AM UTC (7dbef78)">Diff</a>